### PR TITLE
Correct pgvector.sqlalchemy.Vector typo

### DIFF
--- a/backend/migrations/versions/2024_10_10_8e185a868bcc_create_document_table.py
+++ b/backend/migrations/versions/2024_10_10_8e185a868bcc_create_document_table.py
@@ -39,7 +39,7 @@ def upgrade() -> None:
         sa.Column("text", sa.Text(), nullable=False),
         sa.Column(
             "embedding_vector",
-            pgvector.sqlalchemy.vector.VECTOR(dim=PGVECTOR_VECTOR_SIZE),
+            pgvector.sqlalchemy.Vector(dim=PGVECTOR_VECTOR_SIZE),
             nullable=False,
         ),
         sa.Column("created_datetime_utc", sa.DateTime(timezone=True), nullable=False),


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: 20 seconds (maybe 30!)


Fixes this issue:

> 
> I got a "Module does not exist error" running the alembic migration script for ingestion. Did you get the same error when you ran make setup-db? Seems I had the version set up wrong and it should instead be:
> 
> ```
> -            pgvector.sqlalchemy.vector.VECTOR(dim=PGVECTOR_VECTOR_SIZE),
> +            pgvector.sqlalchemy.Vector(dim=PGVECTOR_VECTOR_SIZE),
> ```