### PR TITLE
[HOTFIX] Remove profile from ollama section

### DIFF
--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -23,8 +23,6 @@ services:
         - ./ollama/ollama:/root/.ollama
         - ./run_ollama.sh:/run_ollama.sh
     container_name: ollama
-    profiles:
-        - ollama
     pull_policy: always
     tty: true
     restart: always


### PR DESCRIPTION
Reviewer: @sidravi1 
Estimate: 5 mins

---

## Ticket

Fixes: [JIRA_TICKET_LINK](https://lastmilehealth.atlassian.net/browse/AFHC-58)

## Description

Removes the `profile` section in the `docker-compose.dev.yml` so that Ollama spins up by defauls

### Changes

## How has this been tested?

Ran `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d` and it span up with other containers


## Checklist

Fill with `x` for completed.

- [x] My code follows the style guidelines of this project
- [x] I have reviewed my own code to ensure good quality
- [x] I have tested the functionality of my code to ensure it works as intended
- [x] I have resolved merge conflicts

(Delete any items below that are not relevant)
- [ ] I have updated the automated tests
- [ ] I have updated the scripts in `scripts/`
- [ ] I have updated the requirements
- [ ] I have updated the README file
- [ ] I have updated affected documentation
- [ ] I have updated the CI/CD scripts in `.github/workflows/`
- [ ] I have updated the Terraform code
