### PR TITLE
Remove container name to allow it to recreate

### DIFF
--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -22,7 +22,6 @@ services:
     volumes:
         - ./ollama/ollama:/root/.ollama
         - ./run_ollama.sh:/run_ollama.sh
-    container_name: ollama
     pull_policy: always
     tty: true
     restart: always

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -19,7 +19,6 @@ services:
         - action: rebuild
           path: ../../backend
   chainlit-app:
-    container_name: chainlit-frontend
     build:
       context: ../../chainlit_app
       dockerfile: Dockerfile


### PR DESCRIPTION
Reviewer: @eiyareLMH 
Estimate: 10 mins

---

## Ticket

Fixes: N/A - Hotfix

## Description

### Goal

Jenkins is not able to recreate the chainlit and ollama container since it has a fixed name.
We get the this error:

![image](https://github.com/user-attachments/assets/7fa983f3-4892-423b-a991-4d5e9ddcc620)

